### PR TITLE
fix: add msg-# prefix to message return ids

### DIFF
--- a/apps/dsb-message-broker/src/message/message.controller.ts
+++ b/apps/dsb-message-broker/src/message/message.controller.ts
@@ -41,7 +41,7 @@ export class MessageController {
         try {
             //TODO: change sender to authenticated DID of the sender
             const id = await this.messageService.publish('sender1', message);
-            return id;
+            return `msg-#${id}`;
         } catch (error) {
             this.logger.error(error.message);
             if (error instanceof ChannelNotFoundError) {


### PR DESCRIPTION
This PR adds synthetic `msg-#` prefix to all message ids returns from the publish endpoint, this fixes the issues were some openapi generated client like python does not like "stringified" ints and breaks.