### PR TITLE
feat: explicit clientId for GET /messages endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ EW-DSB is the messaging service of the EW-DOS’s utility layer. Unlike any othe
 
 ## Key features
 
-- Per channel DID based authentication and authorization system
-- At-least-once delivery; exactly once within a window
-- Channels persistency and replayability using consumers
-- Per topic payload schema definitions
+-   Per channel DID based authentication and authorization system
+-   At-least-once delivery; exactly once within a window
+-   Channels persistency and replayability using consumers
+-   Per topic payload schema definitions
 
 _Current DSB implementation is using NATS Jetstream as default transport layer and thus inherits it's characteristics._
 
@@ -267,7 +267,7 @@ Every time user uses `GET /message?fqcn={fqcn}&amount=100` it receives consecuti
 Example:
 
 -   channel `test` has 10 messages `[1,2,3,4,5,6,7,8,9,10]` with order based on publishing order
--   using `GET /message?fqcn=test&amount=3` returns messages `[1,2,3]`
+-   calling `GET /message?fqcn=test&amount=3` returns messages `[1,2,3]`
 -   calling `GET /message?fqcn=test&amount=3` again returns messages `[4,5,6]`
 -   calling `GET /message?fqcn=test&amount=100` returns messages `[7,8,8,9,10]`
 
@@ -277,7 +277,15 @@ This approach of consuming channel data enables control over inflow of messages 
 -   node 2 calls `GET /message?fqcn=test&amount=1000` to get a batch of 1000 messages and repeats when done
 -   node 3 calls `GET /message?fqcn=test&amount=1000` to get a batch of 1000 messages and repeats when done
 
-Note: Currently each node would need to use the same identity to authenticate to DSB Message Broker since consumers are bound to a identity.
+In order to "restart" the stream cursor it's possible to specify `clientId={id}` query parameter.
+
+Example:
+
+-   channel `test` has 10 messages `[1,2,3,4,5,6,7,8,9,10]` with order based on publishing order
+-   calling `GET /message?fqcn=test&amount=3&clientId=1` returns messages `[1,2,3]`
+-   calling `GET /message?fqcn=test&amount=3&clientId=2` returns messages `[1,2,3]`
+-   calling `GET /message?fqcn=test&amount=3&clientId=1` again returns messages `[4,5,6]`
+-   calling `GET /message?fqcn=test&amount=100&clientId=1` returns messages `[7,8,8,9,10]`
 
 Example code:
 

--- a/apps/dsb-message-broker/src/message/message.controller.ts
+++ b/apps/dsb-message-broker/src/message/message.controller.ts
@@ -86,6 +86,12 @@ export class MessageController {
         description: 'Amount of messages to be returned in the request, default value is 100',
         example: '100'
     })
+    @ApiQuery({
+        name: 'clientId',
+        required: false,
+        description: 'Id of the persistent client, default value is ``',
+        example: 'default'
+    })
     @ApiOperation({
         description: 'Pulls new messages from the channel.'
     })
@@ -96,13 +102,15 @@ export class MessageController {
     })
     public async getNewFromChannel(
         @UserDecorator() user: any,
-        @Query(FqcnValidationPipe, MessageQueryPipe) query: { fqcn: string; amount: string }
+        @Query(FqcnValidationPipe, MessageQueryPipe)
+        query: { fqcn: string; amount: string; clientId?: string }
     ): Promise<MessageDto[]> {
         try {
+            const client = `${query.clientId}${user.did}`;
             const messages = await this.messageService.pull(
                 query.fqcn,
                 parseInt(query.amount) ?? this.DEFAULT_AMOUNT,
-                user.did,
+                client,
                 user.verifiedRoles.map((role: any) => role.namespace)
             );
             return messages;

--- a/apps/dsb-message-broker/test/message.e2e-spec.ts
+++ b/apps/dsb-message-broker/test/message.e2e-spec.ts
@@ -255,4 +255,44 @@ describe('MessageController (e2e)', () => {
                 expect(receivedMessages[0].payload).to.be.equal('1');
             });
     });
+
+    it('should be able to restart the consumer by using unique clientId', async () => {
+        const fqcn = 'restart.channels.dsb.apps.energyweb.iam.ewc';
+
+        const message: PublishMessageDto = {
+            fqcn,
+            payload: 'payload',
+            signature: 'sig'
+        };
+
+        await channelManagerService.create({ fqcn });
+
+        await request(app)
+            .post('/message')
+            .send({ ...message, payload: '1' })
+            .expect(HttpStatus.CREATED);
+
+        await request(app)
+            .post('/message')
+            .send({ ...message, payload: '2' })
+            .expect(HttpStatus.CREATED);
+
+        await request(app)
+            .get(`/message?fqcn=${fqcn}&amount=10&clientId=1`)
+            .expect(HttpStatus.OK)
+            .expect((res) => {
+                const messages = res.body as MessageDto[];
+
+                expect(messages).to.have.lengthOf(2);
+            });
+
+        await request(app)
+            .get(`/message?fqcn=${fqcn}&amount=10&clientId=2`)
+            .expect(HttpStatus.OK)
+            .expect((res) => {
+                const messages = res.body as MessageDto[];
+
+                expect(messages).to.have.lengthOf(2);
+            });
+    });
 });

--- a/specs/schema.yaml
+++ b/specs/schema.yaml
@@ -244,6 +244,12 @@ paths:
       summary: ""
       description: "Pulls new messages from the channel."
       parameters:
+        - name: "clientId"
+          required: false
+          in: "query"
+          description: "Id of the persistent client, default value is ``"
+          example: "default"
+          schema: {}
         - name: "amount"
           required: false
           in: "query"


### PR DESCRIPTION
This PR adds ability to specify `clientId` as persistent consumer id for users. This allows end users to "restart" reading from given stream" by specifying unique clientId.

Current behaviour of GET /messages has not been changed.