### PR TITLE
chore: better maximum message size handling

### DIFF
--- a/apps/dsb-message-broker/src/channel/channel.controller.ts
+++ b/apps/dsb-message-broker/src/channel/channel.controller.ts
@@ -65,6 +65,7 @@ export class ChannelController {
         try {
             const channelName = await this.channelService.createChannel({
                 ...createDto,
+                maxMsgSize: createDto.maxMsgSize ?? 1048576, //1Mb default
                 createdBy: user.did,
                 createdDateTime: new Date().toISOString()
             });

--- a/apps/dsb-message-broker/src/channel/dto/create-channel.dto.ts
+++ b/apps/dsb-message-broker/src/channel/dto/create-channel.dto.ts
@@ -5,7 +5,8 @@ import {
     IsDefined,
     IsOptional,
     ArrayNotEmpty,
-    ValidateNested
+    ValidateNested,
+    Max
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -109,10 +110,14 @@ export class CreateChannelDto {
 
     @ApiPropertyOptional({
         type: Number,
-        description: 'Maximum size of any message in the channel, expressed in bytes.',
-        example: 1000000
+        description:
+            'Maximum size of any message in the channel, expressed in bytes. Maximum value is 8388608 bytes (8Mb)',
+        default: 1048576,
+        example: 1048576,
+        maximum: 8388608
     })
     @IsOptional()
     @IsInt()
+    @Max(8388608) //8Mb
     maxMsgSize?: number;
 }

--- a/libs/dsb-transport-nats-js/src/nats-jetstream-transport.ts
+++ b/libs/dsb-transport-nats-js/src/nats-jetstream-transport.ts
@@ -159,7 +159,10 @@ export class NATSJetstreamTransport implements ITransport {
 
             if (error.toString().includes('503')) {
                 throw new ChannelOrTopicNotFoundError(fqcn, topic);
-            } else if (error.toString().includes('message size exceeds maximum allowed')) {
+            } else if (
+                error.toString().includes('message size exceeds maximum allowed') ||
+                error.toString().includes('MAX_PAYLOAD_EXCEEDED')
+            ) {
                 throw new MessageExceedsMaximumSizeError();
             }
 

--- a/specs/schema.yaml
+++ b/specs/schema.yaml
@@ -126,8 +126,10 @@ components:
           example: 86400000000000
         maxMsgSize:
           type: "number"
-          description: "Maximum size of any message in the channel, expressed in bytes."
-          example: 1000000
+          description: "Maximum size of any message in the channel, expressed in bytes. Maximum value is 8388608 bytes (8Mb)"
+          default: 1048576
+          example: 1048576
+          maximum: 8388608
       required:
         - "fqcn"
     UpdateChannelDto:
@@ -180,8 +182,10 @@ components:
           example: 86400000000000
         maxMsgSize:
           type: "number"
-          description: "Maximum size of any message in the channel, expressed in bytes."
-          example: 1000000
+          description: "Maximum size of any message in the channel, expressed in bytes. Maximum value is 8388608 bytes (8Mb)"
+          default: 1048576
+          example: 1048576
+          maximum: 8388608
       required:
         - "fqcn"
     Channel:


### PR DESCRIPTION
This PR adds maximum value of channel message to 8Mb. Also uses 1Mb default as explicit bytes amount.