### PR TITLE
change docker base image to 14-slim and github action runs on ubuntu-…

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,7 +15,7 @@ jobs:
           access_token: ${{ github.token }}
   
   unique_id:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Generate unique id
         id: unique_id
@@ -24,7 +24,7 @@ jobs:
       unique_id: ${{ steps.unique_id.outputs.id }}
 
   install-build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [cancel-previous, unique_id]
     steps:
     - uses: actions/checkout@v2

--- a/apps/dsb-message-broker/Dockerfile
+++ b/apps/dsb-message-broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14-slim
 
 RUN mkdir -p /var/deployment
 COPY ./ /var/deployment


### PR DESCRIPTION
this is to fix the libc difference between 14-apline (musl) and ubuntu-latest(glibc) caused docker image not runable.